### PR TITLE
feat: PostFactory 내 파일 데이터 취득에 대한 Exception 처리 변경

### DIFF
--- a/src/main/java/com/inmybook/adapter/in/web/PostController.java
+++ b/src/main/java/com/inmybook/adapter/in/web/PostController.java
@@ -1,7 +1,5 @@
 package com.inmybook.adapter.in.web;
 
-import java.io.IOException;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -9,7 +7,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.server.ResponseStatusException;
 
 import com.inmybook.adapter.in.web.dto.PostMapper;
 import com.inmybook.adapter.in.web.dto.RegisterPostInput;
@@ -29,13 +26,9 @@ public class PostController {
 	private final RegisterPostUseCase registerPostUseCase;
 	private final PostMapper postMapper;
 
-	@Operation(
-		summary = "독서록 게시글 등록",
-		description = "사용자는 독서록 게시글을 등록할 수 있다."
-	)
+	@Operation(summary = "독서록 게시글 등록", description = "사용자는 독서록 게시글을 등록할 수 있다.")
 	@ApiResponse(
-		responseCode = "201",
-		description = "독서록 게시글 등록 성공"
+		responseCode = "201", description = "독서록 게시글 등록 성공"
 	)
 	@PostMapping(value = "/posts", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
 	public ResponseEntity<String> registerPost(@RequestPart RegisterPostInput registerPostInput,
@@ -43,14 +36,9 @@ public class PostController {
 
 		RegisterPostCommand registerPostCommand = postMapper.createRegisterPostCommand(registerPostInput,
 			multipartFile);
-		String path = "";
-		try {
-			path = registerPostUseCase.registerPost(registerPostCommand);
-		} catch (IOException e) {
-			throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "독서록 게시글을 등록할 수 없습니다.",
-				new IOException());
-		}
+		String path = registerPostUseCase.registerPost(registerPostCommand);
 
 		return new ResponseEntity<>(path, HttpStatus.CREATED);
 	}
+
 }

--- a/src/main/java/com/inmybook/application/port/in/RegisterPostUseCase.java
+++ b/src/main/java/com/inmybook/application/port/in/RegisterPostUseCase.java
@@ -1,7 +1,5 @@
 package com.inmybook.application.port.in;
 
-import java.io.IOException;
-
 public interface RegisterPostUseCase {
 	/**
 	 * @NOTE 사용자가 작성한 독서록 게시글 정보를 등록한다.
@@ -9,5 +7,5 @@ public interface RegisterPostUseCase {
 	 * @param registerPostCommand
 	 * @return 독서록 상세 조회 API Path
 	 */
-	public String registerPost(RegisterPostCommand registerPostCommand) throws IOException;
+	public String registerPost(RegisterPostCommand registerPostCommand);
 }

--- a/src/main/java/com/inmybook/application/service/RegisterPostService.java
+++ b/src/main/java/com/inmybook/application/service/RegisterPostService.java
@@ -1,7 +1,5 @@
 package com.inmybook.application.service;
 
-import java.io.IOException;
-
 import org.springframework.stereotype.Service;
 
 import com.inmybook.application.port.in.RegisterPostCommand;
@@ -19,7 +17,7 @@ public class RegisterPostService implements RegisterPostUseCase {
 	private final RegisterPostPort registerPostPort;
 
 	@Override
-	public String registerPost(RegisterPostCommand registerPostCommand) throws IOException {
+	public String registerPost(RegisterPostCommand registerPostCommand) {
 		Post post = postFactory.createPost(registerPostCommand);
 		Long postNo = registerPostPort.save(post);
 		String path = post.createPostPath(postNo);

--- a/src/main/java/com/inmybook/domain/post/PostFactory.java
+++ b/src/main/java/com/inmybook/domain/post/PostFactory.java
@@ -9,13 +9,17 @@ import com.inmybook.domain.member.Member;
 
 @Component
 public class PostFactory {
-	public Post createPost(RegisterPostCommand registerPostCommand) throws IOException {
+	public Post createPost(RegisterPostCommand registerPostCommand) {
 		Thumbnail thumbnail = new Thumbnail();
 		if (registerPostCommand.thumbnailImg() != null) {
-			thumbnail = new Thumbnail(registerPostCommand.thumbnailImg().getName()
-				, registerPostCommand.thumbnailImg().getContentType()
-				, registerPostCommand.thumbnailImg().getSize()
-				, registerPostCommand.thumbnailImg().getBytes());
+			try {
+				thumbnail = new Thumbnail(registerPostCommand.thumbnailImg().getName()
+					, registerPostCommand.thumbnailImg().getContentType()
+					, registerPostCommand.thumbnailImg().getSize()
+					, registerPostCommand.thumbnailImg().getBytes());
+			} catch (IOException e) {
+				throw new RuntimeException("독서록 게시글을 등록할 수 없습니다.");
+			}
 		}
 
 		Book book = Book.builder()

--- a/src/test/java/com/inmybook/application/service/RegisterPostServiceTest.java
+++ b/src/test/java/com/inmybook/application/service/RegisterPostServiceTest.java
@@ -3,8 +3,6 @@ package com.inmybook.application.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.io.IOException;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,7 +30,7 @@ class RegisterPostServiceTest {
 
 	@Test
 	@DisplayName("사용자는 독서록 게시글을 등록할 수 있다.(썸네일 존재하는 경우)")
-	void registerPostWithUploadImgTest() throws IOException {
+	void registerPostWithUploadImgTest() {
 		// input : 책 정보, 유저 정보, 게시글 정보
 		// output : 상세 조회 url
 
@@ -65,7 +63,7 @@ class RegisterPostServiceTest {
 
 	@Test
 	@DisplayName("사용자는 독서록 게시글을 등록할 수 있다.(썸네일 존재하지 않는 경우)")
-	void registerPostWithoutUploadImgTest() throws IOException {
+	void registerPostWithoutUploadImgTest() {
 		// input : 책 정보, 유저 정보, 게시글 정보
 		// output : 상세 조회 url
 

--- a/src/test/java/com/inmybook/domain/post/PostFactoryTest.java
+++ b/src/test/java/com/inmybook/domain/post/PostFactoryTest.java
@@ -1,0 +1,40 @@
+package com.inmybook.domain.post;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.inmybook.application.port.in.RegisterPostCommand;
+
+@ExtendWith(MockitoExtension.class)
+class PostFactoryTest {
+
+	@Mock
+	RegisterPostCommand registerPostCommand;
+
+	@InjectMocks
+	PostFactory postFactory;
+
+	@Test
+	@DisplayName("Post 객체 생성 시 이미지 데이터 취득 중 IOException 발생 시 RuntimeException 처리")
+	void createPostThrowRuntimeException() throws IOException {
+		MultipartFile mockMultipartFile = mock(MultipartFile.class);
+
+		when(mockMultipartFile.getBytes()).thenThrow(new IOException());
+		when(registerPostCommand.thumbnailImg()).thenReturn(mockMultipartFile);
+
+		assertThatThrownBy(() -> postFactory.createPost(registerPostCommand))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessage("독서록 게시글을 등록할 수 없습니다.");
+
+	}
+}


### PR DESCRIPTION
## 이 PR을 통해 해결하려는 문제
- 도메인 계층의 PostFactory 내에서 Multipart 객체를 통해 파일 데이터를 가져오도록 하는데, 이 과정에서 발생할 수 있는 IOException을 Controller까지 넘겨받도록 처리한 상태이다.
이를 PostFactory 내에서 RuntimeException 처리하여 Exception이 발생한 곳에서 직접 처리되도록 한다.

## 추가 및 변경사항
- PostFactory 내에서 Exception 직접 처리되도록 변경
- PostFactory 클래스로부터 Exception을 넘겨받는 Service와 Controller 내 등록 메서드 시그니처의 throws 키워드 삭제

## 참고(옵션)

## 체크리스트
- [x] 리뷰어를 지정하였는가
- [x] 코드가 오류나 경고없이 빌드되는가
- [x] 추가 및 변경된 사항에 대해 충분히 테스트 하였는가
