### PR TITLE
refactor: 도메인 엔티티 내 id 값 변경에 따른 등록 기능 로직 수정

### DIFF
--- a/src/main/java/com/inmybook/adapter/out/InMemoryPostRepository.java
+++ b/src/main/java/com/inmybook/adapter/out/InMemoryPostRepository.java
@@ -13,9 +13,9 @@ public class InMemoryPostRepository implements RegisterPostPort {
 	private static long sequence = 0L;
 
 	@Override
-	public Long save(Post post) {
-		post.setPostId(++sequence);
-		memory.put(post.getPostId(), post);
+	public String save(Post post) {
+		long id = ++sequence;
+		memory.put(id, post);
 		return post.getPostId();
 	}
 }

--- a/src/main/java/com/inmybook/application/port/out/RegisterPostPort.java
+++ b/src/main/java/com/inmybook/application/port/out/RegisterPostPort.java
@@ -9,5 +9,5 @@ public interface RegisterPostPort {
 	 * @param post
 	 * @return 독서록 상세 조회 API Path
 	 */
-	public Long save(Post post);
+	public String save(Post post);
 }

--- a/src/main/java/com/inmybook/application/service/RegisterPostService.java
+++ b/src/main/java/com/inmybook/application/service/RegisterPostService.java
@@ -19,7 +19,7 @@ public class RegisterPostService implements RegisterPostUseCase {
 	@Override
 	public String registerPost(RegisterPostCommand registerPostCommand) {
 		Post post = postFactory.createPost(registerPostCommand);
-		Long postNo = registerPostPort.save(post);
+		String postNo = registerPostPort.save(post);
 		String path = post.createPostPath(postNo);
 
 		return path;

--- a/src/main/java/com/inmybook/domain/post/Post.java
+++ b/src/main/java/com/inmybook/domain/post/Post.java
@@ -6,22 +6,21 @@ import lombok.Builder;
 
 @Builder
 public class Post {
-	private Long postId;
+	private String postId;
 	private Book book;
 	private Content content;
 	private Thumbnail thumbnail;
 	private Member member;
 
-	public Long getPostId() {
+	public String getPostId() {
 		return postId;
 	}
 
-	public void setPostId(Long postId) {
+	public void setPostId(String postId) {
 		this.postId = postId;
 	}
 
-	public String createPostPath(Long id) {
-		String path = "/post/" + id;
-		return path;
+	public String createPostPath(String id) {
+		return "/posts/" + id;
 	}
 }

--- a/src/main/java/com/inmybook/domain/post/PostFactory.java
+++ b/src/main/java/com/inmybook/domain/post/PostFactory.java
@@ -1,6 +1,7 @@
 package com.inmybook.domain.post;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import org.springframework.stereotype.Component;
 
@@ -46,11 +47,16 @@ public class PostFactory {
 			.build();
 
 		Post post = Post.builder()
+			.postId(getUuid())
 			.book(book)
 			.content(content)
 			.member(member)
 			.build();
 
 		return post;
+	}
+
+	private String getUuid() {
+		return UUID.randomUUID().toString();
 	}
 }

--- a/src/test/java/com/inmybook/application/service/RegisterPostServiceTest.java
+++ b/src/test/java/com/inmybook/application/service/RegisterPostServiceTest.java
@@ -54,9 +54,8 @@ class RegisterPostServiceTest {
 
 		Post post = postFactory.createPost(registerPostCommand);
 		when(mockPostFactory.createPost(registerPostCommand)).thenReturn(post);
-		Long postNo = 1L;
-		when(registerPostPort.save(post)).thenReturn(postNo);
-		String path = post.createPostPath(postNo);
+		when(registerPostPort.save(post)).thenReturn(post.getPostId());
+		String path = post.createPostPath(post.getPostId());
 
 		assertThat(registerPostUseCase.registerPost(registerPostCommand)).isEqualTo(path);
 	}
@@ -87,9 +86,8 @@ class RegisterPostServiceTest {
 
 		Post post = postFactory.createPost(registerPostCommand);
 		when(mockPostFactory.createPost(registerPostCommand)).thenReturn(post);
-		Long postNo = 1L;
-		when(registerPostPort.save(post)).thenReturn(postNo);
-		String path = post.createPostPath(postNo);
+		when(registerPostPort.save(post)).thenReturn(post.getPostId());
+		String path = post.createPostPath(post.getPostId());
 
 		assertThat(registerPostUseCase.registerPost(registerPostCommand)).isEqualTo(path);
 	}


### PR DESCRIPTION
## 이 PR을 통해 해결하려는 문제
- Post 도메인 엔티티 id 값을 DB에서 사용하는 auto increment 값으로 사용
- auto increment 방식으로 생성되는 PK 값은 순차 채번이라는 특성을 가지는데, 이러한 특성으로 인해 외부에 노출될 경우 쉽게 패턴 예측이 가능하여 보안상 취약점을 갖게 된다.
- 따라서 auto increment PK 외 UUID 컬럼을 추가하기로 결정하고 내부적으로는 auto increment 값을, 외부 노출용으로는 랜덤 값인 uuid 를 사용하는 것으로 변경하였다.

## 추가 및 변경사항
- PostFactory 내 uuid 생성 및 postId 세팅 메서드 추가
- InMemoryPostRepository 내 독서록 저장 로직 변경
- 테스트 코드 수정

## 참고(옵션)
- 해당 사항은 #14 코드 리뷰를 계기로 수정하게 되었고 독서록 조회 기능 테스트 코드와 연관된 부분 존재하여 일부 먼저 수정된 바 있다.
- UUID 생성 방식은 가독성이나 DB 공간 낭비 등의 문제로 추후 변경할 가능성 있다.

## 체크리스트
- [x] 리뷰어를 지정하였는가
- [x] 코드가 오류나 경고없이 빌드되는가
- [x] 추가 및 변경된 사항에 대해 충분히 테스트 하였는가
