### PR TITLE
refactor: 독서록 조회 기능 Service Layer dto 테스트 코드 작성

### DIFF
--- a/src/test/java/com/inmybook/application/service/BookDetailsOutputTest.java
+++ b/src/test/java/com/inmybook/application/service/BookDetailsOutputTest.java
@@ -1,0 +1,42 @@
+package com.inmybook.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class BookDetailsOutputTest {
+	@Test
+	@DisplayName("Service Layer 책 정보 응답 DTO Constructor 검증")
+	void testConstructor() {
+		BookDetailsOutput bookDetails = BookDetailsOutput.builder()
+			.isbnNo("9791191824001")
+			.bookName("지구 끝의 온실")
+			.author("김초엽")
+			.publisher("자이언트북스")
+			.build();
+
+		assertNotNull(bookDetails);
+		assertEquals("9791191824001", bookDetails.isbnNo());
+		assertEquals("지구 끝의 온실", bookDetails.bookName());
+		assertEquals("김초엽", bookDetails.author());
+		assertEquals("자이언트북스", bookDetails.publisher());
+	}
+
+	@Test
+	@DisplayName("Service Layer 책 정보 응답 DTO Getter 검증")
+	void testGetter() {
+		BookDetailsOutput bookDetails = BookDetailsOutput.builder()
+			.isbnNo("9791191824001")
+			.bookName("지구 끝의 온실")
+			.author("김초엽")
+			.publisher("자이언트북스")
+			.build();
+
+		assertEquals("9791191824001", bookDetails.isbnNo());
+		assertEquals("지구 끝의 온실", bookDetails.bookName());
+		assertEquals("김초엽", bookDetails.author());
+		assertEquals("자이언트북스", bookDetails.publisher());
+	}
+
+}

--- a/src/test/java/com/inmybook/application/service/ContentDetailsOutputTest.java
+++ b/src/test/java/com/inmybook/application/service/ContentDetailsOutputTest.java
@@ -1,0 +1,57 @@
+package com.inmybook.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ContentDetailsOutputTest {
+	@Test
+	@DisplayName("Service Layer 독서록 정보 응답 DTO Constructor 검증")
+	void testConstructor() {
+		ContentDetailsOutput contentDetails = ContentDetailsOutput.builder()
+			.title("그럼에도 계속 살아간다.")
+			.content("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.")
+			.readingStartDate("2024-09-01")
+			.readingEndDate("2024-09-15")
+			.rating(5.0)
+			.likeCount(0)
+			.bookmarkCount(0)
+			.isPublic("true")
+			.build();
+
+		assertNotNull(contentDetails);
+		assertEquals("그럼에도 계속 살아간다.", contentDetails.title());
+		assertEquals("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.", contentDetails.content());
+		assertEquals("2024-09-01", contentDetails.readingStartDate());
+		assertEquals("2024-09-15", contentDetails.readingEndDate());
+		assertEquals(5.0, contentDetails.rating());
+		assertEquals(0, contentDetails.likeCount());
+		assertEquals(0, contentDetails.bookmarkCount());
+		assertEquals("true", contentDetails.isPublic());
+	}
+
+	@Test
+	@DisplayName("Service Layer 독서록 정보 응답 DTO Getter 검증")
+	void testGetter() {
+		ContentDetailsOutput contentDetails = ContentDetailsOutput.builder()
+			.title("그럼에도 계속 살아간다.")
+			.content("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.")
+			.readingStartDate("2024-09-01")
+			.readingEndDate("2024-09-15")
+			.rating(5.0)
+			.likeCount(200)
+			.bookmarkCount(75)
+			.isPublic("false")
+			.build();
+
+		assertEquals("그럼에도 계속 살아간다.", contentDetails.title());
+		assertEquals("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.", contentDetails.content());
+		assertEquals("2024-09-01", contentDetails.readingStartDate());
+		assertEquals("2024-09-15", contentDetails.readingEndDate());
+		assertEquals(5.0, contentDetails.rating());
+		assertEquals(200, contentDetails.likeCount());
+		assertEquals(75, contentDetails.bookmarkCount());
+		assertEquals("false", contentDetails.isPublic());
+	}
+}

--- a/src/test/java/com/inmybook/application/service/MemberDetailsOutputTest.java
+++ b/src/test/java/com/inmybook/application/service/MemberDetailsOutputTest.java
@@ -1,0 +1,48 @@
+package com.inmybook.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class MemberDetailsOutputTest {
+
+	String memberId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		memberId = getUuid();
+	}
+
+	@Test
+	@DisplayName("Service Layer 사용자 정보 응답 DTO Constructor 검증")
+	void testConstructor() {
+		MemberDetailsOutput memberDetails = MemberDetailsOutput.builder()
+			.memberId(memberId)
+			.nickname("JohnDoe")
+			.build();
+
+		assertNotNull(memberDetails);
+		assertEquals(memberId, memberDetails.memberId());
+		assertEquals("JohnDoe", memberDetails.nickname());
+	}
+
+	@Test
+	@DisplayName("Service Layer 사용자 정보 응답 DTO Getter 검증")
+	void testGetter() {
+		MemberDetailsOutput memberDetails = MemberDetailsOutput.builder()
+			.memberId(memberId)
+			.nickname("JaneDoe")
+			.build();
+
+		assertEquals(memberId, memberDetails.memberId());
+		assertEquals("JaneDoe", memberDetails.nickname());
+	}
+
+	private String getUuid() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/src/test/java/com/inmybook/application/service/PostDetailsOutputTest.java
+++ b/src/test/java/com/inmybook/application/service/PostDetailsOutputTest.java
@@ -1,0 +1,86 @@
+package com.inmybook.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PostDetailsOutputTest {
+
+	String memberId;
+	String postId;
+
+	@BeforeEach
+	void setUp() throws Exception {
+		memberId = getUuid();
+		postId = getUuid();
+	}
+
+	@Test
+	@DisplayName("Service Layer 사용자 정보를 포함한 독서록 정보(책 정보 제외) 응답 DTO Constructor 검증")
+	void testConstructor() {
+		ContentDetailsOutput contentDetails = ContentDetailsOutput.builder()
+			.title("그럼에도 계속 살아간다.")
+			.content("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.")
+			.readingStartDate("2024-09-01")
+			.readingEndDate("2024-09-15")
+			.rating(4.5)
+			.likeCount(120)
+			.bookmarkCount(50)
+			.isPublic("true")
+			.build();
+
+		MemberDetailsOutput memberDetails = MemberDetailsOutput.builder()
+			.memberId(memberId)
+			.nickname("JohnDoe")
+			.build();
+
+		PostDetailsOutput postDetails = PostDetailsOutput.builder()
+			.postId(postId)
+			.contentDetailsOutput(contentDetails)
+			.memberDetailsOutput(memberDetails)
+			.build();
+
+		assertNotNull(postDetails);
+		assertEquals(postId, postDetails.postId());
+		assertEquals(contentDetails, postDetails.contentDetailsOutput());
+		assertEquals(memberDetails, postDetails.memberDetailsOutput());
+	}
+
+	@Test
+	@DisplayName("Service Layer 사용자 정보를 포함한 독서록 정보(책 정보 제외) 응답 DTO Getter 검증")
+	void testGetter() {
+		ContentDetailsOutput contentDetails = ContentDetailsOutput.builder()
+			.title("그럼에도 계속 살아간다.")
+			.content("더스트로 뿌옇게 뒤덮인 미래가 계속 될지라도 희망은 계속된다.")
+			.readingStartDate("2024-09-01")
+			.readingEndDate("2024-09-15")
+			.rating(4.8)
+			.likeCount(200)
+			.bookmarkCount(75)
+			.isPublic("false")
+			.build();
+
+		MemberDetailsOutput memberDetails = MemberDetailsOutput.builder()
+			.memberId(memberId)
+			.nickname("JaneDoe")
+			.build();
+
+		PostDetailsOutput postDetails = PostDetailsOutput.builder()
+			.postId(postId)
+			.contentDetailsOutput(contentDetails)
+			.memberDetailsOutput(memberDetails)
+			.build();
+
+		assertEquals(postId, postDetails.postId());
+		assertEquals(contentDetails, postDetails.contentDetailsOutput());
+		assertEquals(memberDetails, postDetails.memberDetailsOutput());
+	}
+
+	private String getUuid() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/src/test/java/com/inmybook/application/service/ThumbnailDetailsOutputTest.java
+++ b/src/test/java/com/inmybook/application/service/ThumbnailDetailsOutputTest.java
@@ -1,0 +1,34 @@
+package com.inmybook.application.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class ThumbnailDetailsOutputTest {
+	@Test
+	@DisplayName("Service Layer 사용자가 직접 등록한 썸네일 정보 응답 DTO Constructor 검증")
+	void testConstructor() {
+		byte[] thumbnailData = new byte[] {1, 2, 3, 4, 5};
+
+		ThumbnailDetailsOutput thumbnailDetails = ThumbnailDetailsOutput.builder()
+			.thumbnailData(thumbnailData)
+			.build();
+
+		assertNotNull(thumbnailDetails);
+		assertArrayEquals(thumbnailData, thumbnailDetails.thumbnailData());
+	}
+
+	@Test
+	@DisplayName("Service Layer 사용자가 직접 등록한 썸네일 정보 응답 DTO Constructor 검증")
+	void testGetter() {
+		byte[] thumbnailData = new byte[] {10, 20, 30, 40, 50};
+
+		ThumbnailDetailsOutput thumbnailDetails = ThumbnailDetailsOutput.builder()
+			.thumbnailData(thumbnailData)
+			.build();
+
+		assertArrayEquals(thumbnailData, thumbnailDetails.thumbnailData());
+	}
+
+}


### PR DESCRIPTION
## 이 PR을 통해 해결하려는 문제
- 독서록 단 건 조회 기능 Service Layer 응답 dto에 대한 테스트 코드를 작성하여 코드 정확성을 보장하고 애플리케이션 안정성을 유지한다.

## 추가 및 변경사항
- 각 dto 클래스에 대한 테스트 코드 작성
- MemberDetailsOutput 내 auto increment와 매치되는 memberNo 필드 삭제, memberId 는 uuid 로 세팅할 것을 감안하여 작성
   (~~따로 PR 올릴 예정~~ PR 요청 완료)

## 참고(옵션)
- Member 관련 도메인 클래스와 dto 클래스 수정 예정

## 체크리스트
- [x] 리뷰어를 지정하였는가
- [ ] 코드가 오류나 경고없이 빌드되는가
- [x] 추가 및 변경된 사항에 대해 충분히 테스트 하였는가
